### PR TITLE
Update 05-xpath.Rmd

### DIFF
--- a/book/05-xpath.Rmd
+++ b/book/05-xpath.Rmd
@@ -532,5 +532,18 @@ lengthy_art <-
 art_p[lengthy_art] %>%
   xml_find_all(".//h2/a") %>%
   xml_text()
+
+# alternative solution
+nodes <-
+  newspaper |> 
+  xml_find_all("//article[./p[@class = 'c_d']]")
+
+nodes |> 
+  xml_children() |> 
+  xml_find_all("//p") |> 
+  xml_text() |> 
+  str_replace("(\n|\\\\n)", "") |> 
+  nchar() |> 
+  which.max()
 ```
 


### PR DESCRIPTION
At the end of the document I provide an alternative solution for the last task. You specify that only the subtitle should be counted. However, I noticed that when one collects all p nodes for some reason it also collects the nodes defining the title of the article and the journalist. To circumvent that I save all nodes and the look for the children (the collection of all tags under p, which for some reason also collects the header and div tags). I then specify that I only want the p tags. This gives me all the subtitles. I tried removing all "\n", but that did not work. Maybe we could figure that out in class. The result then is different with the fifth article having the longest subtitle.